### PR TITLE
Docker-compose and docker-sync templates upgraded to framework 7.0.0-beta1

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -1,11 +1,13 @@
 version: "3.1"
 services:
     postgres:
-        image: postgres:9.5-alpine
+        image: postgres:10.5-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - shopsys-framework-postgres-data-sync:/var/lib/postgresql/data
+            - ./docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
+            - ./var/postgres-data:/var/lib/postgresql/data:cached
         environment:
+            - PGDATA=/var/lib/postgresql/data/pgdata
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
@@ -14,8 +16,8 @@ services:
         image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
         volumes:
-            - shopsys-framework-sync:/var/www/html
-            - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+            - shopsys-framework-web-sync:/var/www/html/web
+            - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:delegated
         ports:
             - "8000:8080"
         links:
@@ -28,10 +30,12 @@ services:
             args:
                 www_data_uid: 501
                 www_data_gid: 20
+                github_oauth_token: place-your-token-here
         container_name: shopsys-framework-php-fpm
         volumes:
             - shopsys-framework-sync:/var/www/html
-            - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
+            - shopsys-framework-vendor-sync:/var/www/html/vendor
+            - shopsys-framework-web-sync:/var/www/html/web
         links:
             - postgres
             - redis
@@ -92,9 +96,26 @@ services:
         ports:
             - "9200:9200"
         volumes:
+            - ./var/elasticsearch-data:/usr/share/elasticsearch/data:cached
             - shopsys-framework-elasticsearch-data-sync:/usr/share/elasticsearch/data
         environment:
             - discovery.type=single-node
+
+    microservice-product-search:
+        image: shopsys/microservice-product-search:v7.0.0-beta1
+        container_name: shopsys-framework-microservice-product-search
+        links:
+            - elasticsearch
+        depends_on:
+            - elasticsearch
+
+    microservice-product-search-export:
+        image: shopsys/microservice-product-search-export:v7.0.0-beta1
+        container_name: shopsys-framework-microservice-product-search-export
+        links:
+            - elasticsearch
+        depends_on:
+            - elasticsearch
 
 volumes:
     shopsys-framework-sync:
@@ -104,4 +125,10 @@ volumes:
         external: true
 
     shopsys-framework-elasticsearch-data-sync:
+        external: true
+
+    shopsys-framework-vendor-sync:
+        external: true
+
+    shopsys-framework-web-sync:
         external: true

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -1,12 +1,13 @@
 version: "3.1"
 services:
     postgres:
-        image: postgres:9.5-alpine
+        image: postgres:10.5-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - pgdata:/var/lib/postgresql/data
+            - ./docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf
         environment:
-            - PGDATA=/var/lib/postgresql/data
+            - PGDATA=/var/lib/postgresql/data/pgdata
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
@@ -29,10 +30,10 @@ services:
             args:
                 www_data_uid: 82
                 www_data_gid: 82
+                github_oauth_token: place-your-token-here
         container_name: shopsys-framework-php-fpm
         volumes:
             - .:/var/www/html
-            - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - postgres
             - redis
@@ -97,8 +98,24 @@ services:
         environment:
             - discovery.type=single-node
 
+    microservice-product-search:
+        image: shopsys/microservice-product-search:v7.0.0-beta1
+        container_name: shopsys-framework-microservice-product-search
+        links:
+            - elasticsearch
+        depends_on:
+            - elasticsearch
+
+    microservice-product-search-export:
+        image: shopsys/microservice-product-search-export:v7.0.0-beta1
+        container_name: shopsys-framework-microservice-product-search-export
+        links:
+            - elasticsearch
+        depends_on:
+            - elasticsearch
+
 volumes:
     pgdata:
         driver: local
     elasticsearch-data:
-      driver: local
+        driver: local

--- a/docker/conf/docker-sync.yml.dist
+++ b/docker/conf/docker-sync.yml.dist
@@ -3,7 +3,36 @@ syncs:
     shopsys-framework-sync:
         sync_userid: 501
         src: './'
-        sync_excludes: ['docker/']
+        sync_excludes: [
+            'docker/',
+            '.git',
+            '.idea',
+            '.docker-sync',
+            '.DS_Store',
+            'docker',
+            'node_modules',
+            'var/cache',
+            'var/postgres-data',
+            'var/elasticsearch-data',
+            'web',
+            'vendor'
+        ]
+        host_disk_mount_mode: 'delegated'
 
     shopsys-framework-postgres-data-sync:
         src: './var/postgres-data/'
+        host_disk_mount_mode: 'cached'
+
+    shopsys-framework-elasticsearch-data-sync:
+        src: './var/elasticsearch-data/'
+        host_disk_mount_mode: 'cached'
+
+    shopsys-framework-web-sync:
+        sync_userid: 501
+        src: './web'
+        host_disk_mount_mode: 'cached'
+
+    shopsys-framework-vendor-sync:
+        sync_userid: 501
+        src: './vendor'
+        host_disk_mount_mode: 'cached'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Old templates are not prepared for usage with framework 7.0.0-beta1
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
