### PR TITLE
elasticsearch service is restarted if it fails on error

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -89,6 +89,7 @@ services:
             nofile:
                 soft: 65536
                 hard: 65536
+        restart: on-failure
         ports:
             - "9200:9200"
         volumes:

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -90,6 +90,7 @@ services:
             nofile:
                 soft: 65536
                 hard: 65536
+        restart: on-failure
         ports:
             - "9200:9200"
         volumes:

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -94,6 +94,7 @@ services:
             nofile:
                 soft: 65536
                 hard: 65536
+        restart: on-failure
         ports:
             - "9200:9200"
         volumes:


### PR DESCRIPTION
restart parameter for elasticsearch service was added into docker-compose.yml.dist configuration files

| Q             | A
| ------------- | ---
|Description, reason for the PR| sometimes when multiple instances of demoshop run on the ci server elasticsearch container fails on error 137 and it needs to be restarted so searching microservices start to work again
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #21
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
