### PR TITLE
Ability to install demo instances

### DIFF
--- a/.ci/build_demo.sh
+++ b/.ci/build_demo.sh
@@ -1,0 +1,102 @@
+#!/bin/bash -e
+
+# Builds a new demo instance using Docker Compose.
+# Uses URLs http://<demo_domain> and http://2.<demo_domain>
+# Adds nginx configuration into /etc/nginx/conf.d/<JOB_NAME>.conf
+#
+# Usage: build_demo.sh <demo_domain>
+#
+# Example: build_demo.sh my-demo.example.com
+
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+BLUE="\e[34m"
+NC="\e[0m"
+
+DEMO_DOMAIN=$1
+JOB_NAME=${JOB_NAME:-$DEMO_DOMAIN}
+WORKSPACE=${WORKSPACE:-$PWD}
+
+if [[ ! "$DEMO_DOMAIN" =~ ^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$ ]]; then
+    echo -e "${RED}Invalid demo domain!${NC}"
+    echo -e "${BLUE}Use only lowercase letters and numbers, you can include dashes and dots in the middle (eg. \"my-demo42.example.com\").${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}Configuring your demo-shop...${NC}"
+
+# Configuration files are baked into the Docker image at the moment
+cp "$WORKSPACE/app/config/parameters.yml.dist" "$WORKSPACE/app/config/parameters.yml"
+cp "$WORKSPACE/app/config/domains_urls.yml.dist" "$WORKSPACE/app/config/domains_urls.yml"
+
+# Disable master e-mail and mailer whitelist
+sed -i "s/mailer_master_email_address:.*/mailer_master_email_address: ~/" "$WORKSPACE/app/config/parameters.yml"
+sed -i "s/mailer_delivery_whitelist:.*/mailer_delivery_whitelist: ~/" "$WORKSPACE/app/config/parameters.yml"
+
+# Fetch all domain IDs
+DOMAIN_IDS=$(cat "$WORKSPACE/app/config/domains_urls.yml" | grep -Po 'id: ([0-9]+)$' | sed -r 's/id: ([0-9]+)/\1/')
+
+# Modify public URLs to $DOMAIN_ID.$DEMO_DOMAIN ($DOMAIN_ID is omitted for the first domain)
+for DOMAIN_ID in $DOMAIN_IDS; do
+    if [[ "$DOMAIN_ID" == "1" ]]; then
+        # 1st domain has URL without a number prefix
+        sed -i "/id: 1/,/url:/{s/url:.*/url: http:\/\/$DEMO_DOMAIN/}" "$WORKSPACE/app/config/domains_urls.yml"
+    else
+        # 2nd and subsequent domains have URLs with DOMAIN_ID prefix
+        sed -i "/id: $DOMAIN_ID/,/url:/{s/url:.*/url: http:\/\/$DOMAIN_ID.$DEMO_DOMAIN/}" "$WORKSPACE/app/config/domains_urls.yml"
+    fi
+done
+
+# Copy the demo Docker Compose configuration
+cp docker/conf/docker-compose.demo.yml.dist docker-compose.yml
+
+echo -e "${BLUE}Building Docker images and starting up the containers...${NC}"
+
+# Build the Docker image and start the containers
+docker-compose up --build --force-recreate -d
+
+# Configure the nginx
+echo "upstream $JOB_NAME-upstream {
+    server $(docker-compose port webserver 8080);
+}
+
+server {
+    listen 80;
+    server_name $DEMO_DOMAIN *.$DEMO_DOMAIN;
+
+    location / {
+        proxy_pass http://$JOB_NAME-upstream;
+        proxy_redirect off;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host \$host;
+    }
+}" > "/etc/nginx/conf.d/$JOB_NAME.conf"
+
+# Reload nginx to apply the new configuration
+# "jenkins" user has been allowed to run "nginx" command as super-user without password prompt via /etc/sudoers configuration
+# see https://www.digitalocean.com/community/tutorials/how-to-edit-the-sudoers-file-on-ubuntu-and-centos#how-to-modify-the-sudoers-file
+sudo nginx -s reload
+
+echo -e "${BLUE}Building the application...${NC}"
+
+# Wait a moment for postgres to start, ten seconds should suffice
+# (avoids having to implement a check according to https://docs.docker.com/compose/startup-order/)
+sleep 10
+
+# Build the application inside php-fpm container
+docker-compose exec -T php-fpm ./phing db-create db-demo grunt error-pages-generate microservice-product-search-recreate-structure microservice-product-search-export-products warmup
+
+# Display success message and available domains
+echo -e "${GREEN}Demo-shop \"$DEMO_DOMAIN\" successfully created!${NC}"
+echo "It's publicly accessible on these URLs:"
+for DOMAIN_ID in $DOMAIN_IDS; do
+    if [[ "$DOMAIN_ID" == "1" ]]; then
+        echo -e "- ${BLUE}http://$DEMO_DOMAIN${NC}"
+        echo -e "- ${BLUE}http://$DEMO_DOMAIN/admin${NC}"
+    else
+        echo -e "- ${BLUE}http://$DOMAIN_ID.$DEMO_DOMAIN${NC}"
+    fi
+done

--- a/.ci/check_jenkins_job_status.sh
+++ b/.ci/check_jenkins_job_status.sh
@@ -1,0 +1,37 @@
+#!/bin/bash +ex
+
+# Checks whether a specified Jenkins job succeeded in the last build.
+#
+# Expects $JENKINS_URL (url of Jenkins) to be set as environment variables
+#
+# Usage: check_jenkins_job_status.sh <check_job_name>
+#
+# Example: check_jenkins_job_status.sh  master
+
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+BLUE="\e[34m"
+NC="\e[0m"
+
+CHECK_JOB_NAME=$1
+
+# Use Python to parse the JSON as it is usually installed on a machine
+JOB_STATUS=$(curl -s "$JENKINS_URL/job/$CHECK_JOB_NAME/lastBuild/api/json" | python -c "import sys, json; print json.load(sys.stdin)['result']")
+
+if [[ ! $? -eq 0 ]]; then
+    echo -e "${RED}The status of $CHECK_JOB_NAME could not be obtained.${NC}\nMaybe the job does not exists."
+    exit 1
+fi
+
+case "$JOB_STATUS" in
+"SUCCESS") echo -e "${GREEN}The last build of $CHECK_JOB_NAME succeeded.${NC}" ;;
+"FAILURE") echo -e "${RED}The last build of $CHECK_JOB_NAME failed!${NC}" ;;
+"None")    echo -e "${RED}The last build of $CHECK_JOB_NAME has no status!${NC}\nMaybe the build has not finished yet." ;;
+*)         echo -e "${RED}Unexpected status of $CHECK_JOB_NAME: \"$JOB_STATUS\"!${NC}" ;;
+esac
+
+if [[ "$JOB_STATUS" != "SUCCESS" ]]; then
+    echo -e "Check the details on ${BLUE}"${JENKINS_URL%/}/job/$CHECK_JOB_NAME"${NC}"
+    exit 1
+fi

--- a/.ci/create_jenkins_job.sh
+++ b/.ci/create_jenkins_job.sh
@@ -1,0 +1,61 @@
+#!/bin/bash +ex
+
+# Creates a new Jenkins job from a template, enables it and builds it.
+#
+# Uses Jenkins CLI (https://jenkins.io/doc/book/managing/cli/)
+# Expects $JENKINS_URL (url of Jenkins) and $JENKINS_CLI_JAR (path to jenkins-cli.jar) to be set as environment variables
+#
+# Usage: create_jenkins_job.sh <new_job_name> <template_job_name> [<view_name>]
+#
+# Example: create_jenkins_job.sh $BUILD_PARAMETER template demos
+
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+BLUE="\e[34m"
+NC="\e[0m"
+
+NEW_JOB_NAME=$1
+TEMPLATE_JOB_NAME=$2
+VIEW_NAME=$3
+
+if [[ ! "$NEW_JOB_NAME" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+    echo -e "${RED}Invalid project name!${NC}"
+    echo -e "${BLUE}Use only lowercase letters and numbers, you can include dashes in the middle (eg. \"my-demo-42\").${NC}"
+    exit 1
+fi
+if [[ -z "$JENKINS_URL" ]]; then
+    echo -e "${RED}Jenkins URL has not been provided (in \$JENKINS_URL environment variable)!${NC}"
+    exit 1
+fi
+if [[ -z "$JENKINS_CLI_JAR" ]]; then
+    echo -e "${RED}Path to the Jenkins CLI jarfile has not been provided (in \$JENKINS_CLI_JAR environment variable)!${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}Creating a new project \"$NEW_JOB_NAME\"...${NC}"
+
+java -jar "$JENKINS_CLI_JAR" -s "$JENKINS_URL" copy-job "$TEMPLATE_JOB_NAME" "$NEW_JOB_NAME"
+if [[ ! $? -eq 0 ]]; then
+    echo -e "${RED}Project creation failed!${NC}"
+    exit 1
+fi
+
+if [[ -n "$VIEW_NAME" ]]; then
+    java -jar "$JENKINS_CLI_JAR" -s "$JENKINS_URL" add-job-to-view "$VIEW_NAME" "$NEW_JOB_NAME"
+fi
+java -jar "$JENKINS_CLI_JAR" -s "$JENKINS_URL" enable-job "$NEW_JOB_NAME"
+
+JENKINS_JOB_URL="${JENKINS_URL%/}/job/$NEW_JOB_NAME"
+echo -e "${BLUE}Building the new project...${NC} ($JENKINS_JOB_URL)"
+
+java -jar "$JENKINS_CLI_JAR" -s "$JENKINS_URL" build -f -v "$NEW_JOB_NAME"
+if [[ ! $? -eq 0 ]]; then
+    echo -e "${RED}Build of the new project has failed!${NC}"
+    echo -e "Check the details of the build on ${BLUE}$JENKINS_JOB_URL${NC}"
+    echo -e "You can either try to rebuild it manually or delete it"
+    exit 1
+fi
+
+echo -e "${GREEN}Project \"$NEW_JOB_NAME\" created and built successfully!${NC}"
+echo -e "You can delete it on ${BLUE}$JENKINS_JOB_URL${NC} when you don't need it anymore"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Added
+- [#34 - Ability to install demo instances](https://github.com/shopsys/demoshop/pull/34)
 - [#7 - Product now has condition attribute that is displayed on product detail page and is generated in google feed](https://github.com/shopsys/demoshop/pull/7)
 - [#8 - Category now has second description attribute that is displayed on the product list page above the product list](https://github.com/shopsys/demoshop/pull/8)
 - [#9 - Introduced a quick way to improve performance by caching in twig templates](https://github.com/shopsys/demoshop/pull/9)

--- a/docker/conf/docker-compose.demo.yml.dist
+++ b/docker/conf/docker-compose.demo.yml.dist
@@ -34,20 +34,28 @@ services:
     smtp-server:
         image: namshi/smtp:latest
 
-    elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
-        ulimits:
-            nofile:
-                soft: 65536
-                hard: 65536
-        environment:
-            - discovery.type=single-node
-
     microservice-product-search:
-        image: shopsys/microservice-product-search:v7.0.0-beta4
+        image: shopsys/microservice-product-search:v7.0.0-beta5
+        environment:
+            - ELASTICSEARCH_HOSTS_STRING=$ELASTICSEARCH_IP:9200
+            - ELASTIC_SEARCH_INDEX_PREFIX=$JOB_NAME-
+        networks:
+            - default
+            - shared-elastic
 
     microservice-product-search-export:
-        image: shopsys/microservice-product-search-export:v7.0.0-beta4
+        image: shopsys/microservice-product-search-export:v7.0.0-beta5
+        environment:
+            - ELASTICSEARCH_HOSTS_STRING=$ELASTICSEARCH_IP:9200
+            - ELASTIC_SEARCH_INDEX_PREFIX=$JOB_NAME-
+        networks:
+            - default
+            - shared-elastic
 
 volumes:
-  web-volume: ~
+    web-volume: ~
+
+networks:
+    shared-elastic:
+        external:
+            name: ${ELASTICSEARCH_NETWORK:-shared-demo-elasticsearch-network}

--- a/docker/conf/docker-compose.demo.yml.dist
+++ b/docker/conf/docker-compose.demo.yml.dist
@@ -1,0 +1,53 @@
+version: "3.4"
+services:
+    postgres:
+        image: postgres:10.5-alpine
+        volumes:
+            - ./docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:ro
+        environment:
+            - PGDATA=/var/lib/postgresql/data/pgdata
+            - POSTGRES_USER=root
+            - POSTGRES_PASSWORD=root
+            - POSTGRES_DB=shopsys
+
+    webserver:
+        image: nginx:1.13-alpine
+        depends_on:
+            - php-fpm
+        volumes:
+            - web-volume:/var/www/html/web
+            - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+        ports:
+            - "8080"
+
+    php-fpm:
+        build:
+            context: .
+            dockerfile: docker/php-fpm/Dockerfile
+            target: production
+        volumes:
+            - web-volume:/var/www/html/web
+
+    redis:
+        image: redis:4.0-alpine
+
+    smtp-server:
+        image: namshi/smtp:latest
+
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
+        ulimits:
+            nofile:
+                soft: 65536
+                hard: 65536
+        environment:
+            - discovery.type=single-node
+
+    microservice-product-search:
+        image: shopsys/microservice-product-search:v7.0.0-beta4
+
+    microservice-product-search-export:
+        image: shopsys/microservice-product-search-export:v7.0.0-beta4
+
+volumes:
+  web-volume: ~


### PR DESCRIPTION
This PR allows starting up a demo instance using Jenkins with a very simple set-up.

You can just have two jobs created in your Jenkins:
**template** - a disabled job that just calls the `.ci/build_demo.sh` script
**installer** - a job with parameterized build that just calls `.ci/create_jenkins_job.sh $PARAMETER template` which copies the template job and runs it

There is a shared container with Elasticsearch as it consumes too much memory. Using Docker Compose only 31 networks can be created (using the default setting), so that's an upper bound on running demo instances for the time being. I've managed to run 20 demo instances without any problems on our demo server with 8 GiB of RAM (and there were other job running at that time). Build has typically taken around 4 minutes there.

The `.ci/build_demo.sh` script has some assumptions about the server configuration (eg. requires nginx installed), check and modify the script before running it yourself. I've tried to provide some comments, hope it's enough.

| Q             | A
| ------------- | ---
|Description, reason for the PR| This enables starting up a demo instance easily using a shell script or Jenkins.
|New feature| Yes <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
