### PR TITLE
pagination url parameter is fixed based on upgrade notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [#8 - Category now has second description attribute that is displayed on the product list page above the product list](https://github.com/shopsys/demoshop/pull/8)
     - GoogleFeedItemFactory: removed unused imports
+- [#38 - Pagination url parameter is fixed based on upgrade notes](https://github.com/shopsys/demoshop/pull/38)
 
 ### Removed
 - [#36 - Production Docker file was removed due to multistage build](https://github.com/shopsys/demoshop/pull/36)

--- a/src/Shopsys/ShopBundle/Resources/views/Front/Inline/Paginator/paginator.html.twig
+++ b/src/Shopsys/ShopBundle/Resources/views/Front/Inline/Paginator/paginator.html.twig
@@ -17,12 +17,12 @@
                     {% if page == 1 %}
                         {% set page = null %}
                     {% endif %}
-                    {% set routeParams = routeParams|merge({pageQueryParameter: page}) %}
+                    {% set routeParams = routeParams|merge({(pageQueryParameter): page}) %}
                     <a class="in-paging__control__item in-paging__control__item--arrow" href="{{ path(route, routeParams) }}" rel ="prev">
                         <span class="svg svg-arrow in-rotate--90"></span>
                     </a>
 
-                    {% set routeParams = routeParams|merge({pageQueryParameter: null}) %}
+                    {% set routeParams = routeParams|merge({(pageQueryParameter): null}) %}
                     {% if paginationResult.page == 2 %}
                         <a class="in-paging__control__item in-paging__control__item--num" href="{{ path(route, routeParams) }}" rel="prev">1</a>
                     {% else %}
@@ -41,7 +41,7 @@
                 {% endif %}
 
                 {% for page in (paginationResult.page - pagerExpand)..(paginationResult.page) if page > 1 and page < paginationResult.page %}
-                    {% set routeParams = routeParams|merge({pageQueryParameter: page}) %}
+                    {% set routeParams = routeParams|merge({(pageQueryParameter): page}) %}
                     {% if page == (paginationResult.page - 1) %}
                         <a class='in-paging__control__item in-paging__control__item--num' href="{{ path(route, routeParams) }}" rel="prev">{{ page }}</a>
                     {% else %}
@@ -52,7 +52,7 @@
                 <span class="in-paging__control__item in-paging__control__item--num in-paging__control__item in-paging__control__item--num--active">{{ paginationResult.page }}</span>
 
                 {% for page in (paginationResult.page + 1)..(paginationResult.page + pagerExpand) if page > paginationResult.page and page < pageCount %}
-                    {% set routeParams = routeParams|merge({pageQueryParameter: page}) %}
+                    {% set routeParams = routeParams|merge({(pageQueryParameter): page}) %}
                     {% if page == (paginationResult.page + 1) %}
                         <a class="in-paging__control__item in-paging__control__item--num" href="{{ path(route, routeParams) }}" rel="next">{{ page }}</a>
                     {% else %}
@@ -65,14 +65,14 @@
                 {% endif %}
 
                 {% if paginationResult.page < pageCount %}
-                    {% set routeParams = routeParams|merge({pageQueryParameter: pageCount}) %}
+                    {% set routeParams = routeParams|merge({(pageQueryParameter): pageCount}) %}
                     {% if paginationResult.page == (pageCount - 1) %}
                         <a class="in-paging__control__item in-paging__control__item--num" href="{{ path(route, routeParams) }}" rel="next">{{ pageCount }}</a>
                     {% else %}
                         <a class="in-paging__control__item in-paging__control__item--num" href="{{ path(route, routeParams) }}">{{ pageCount }}</a>
                     {% endif %}
 
-                    {% set routeParams = routeParams|merge({pageQueryParameter: paginationResult.page + 1}) %}
+                    {% set routeParams = routeParams|merge({(pageQueryParameter): paginationResult.page + 1}) %}
                     <a class="in-paging__control__item in-paging__control__item--arrow in-paging__control__item in-paging__control__item--arrow" href="{{ path(route, routeParams) }}" rel="next"><span class="svg svg-arrow in-rotate--270"></span></a>
                 {% else %}
                     <span class="in-paging__control__item in-paging__control__item--arrow in-paging__control__item--arrow--inactive"><span class="svg svg-arrow in-rotate--270"></span></span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| during beta5 upgrade some parts of the commit for pagination plugin were not correctly transferred into demoshop so page url parameter is reflected by variable key not the value.
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
