### PR TITLE
Autocomplete action for pickup place controller needs to be upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#8 - Category now has second description attribute that is displayed on the product list page above the product list](https://github.com/shopsys/demoshop/pull/8)
     - GoogleFeedItemFactory: removed unused imports
 - [#38 - Pagination url parameter is fixed based on upgrade notes](https://github.com/shopsys/demoshop/pull/38)
+- [#43 - Autocomplete action for pickup place controller is fixed based on upgrade notes](https://github.com/shopsys/demoshop/pull/43)
 
 ### Removed
 - [#36 - Production Docker file was removed due to multistage build](https://github.com/shopsys/demoshop/pull/36)

--- a/src/Shopsys/ShopBundle/Controller/Front/PickUpPlaceController.php
+++ b/src/Shopsys/ShopBundle/Controller/Front/PickUpPlaceController.php
@@ -63,7 +63,7 @@ class PickUpPlaceController extends FrontBaseController
         $countryCodes = array_map(function ($country) {
             /** @var $country \Shopsys\FrameworkBundle\Model\Country\Country */
             return strtolower($country->getCode());
-        }, $this->countryFacade->getAllOnCurrentDomain());
+        }, $this->countryFacade->getAllEnabledOnCurrentDomain());
 
         $pickUpPlaces = $this->pickUpPlaceFacade->findActiveBySearchQueryAndTransportType(
             $searchQuery,


### PR DESCRIPTION
- upgrade instruction for renaming getAllOnCurrentDomain into getAllEnabledOnCurrentDomain was applied

| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #41 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
