### PR TITLE
PULL_REQUEST_TEMPLATE.md: remove BC break section

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@
 | ------------- | ---
 |Description, reason for the PR| ...
 |New feature| Yes/No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
-|BC breaks| Yes/No <!-- Do not forget to update UPGRADE.md -->
 |Fixes issues| ...
 |Standards and tests pass| Yes/No
 |Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes/No


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| I want to  remove the *BC breaks* section from PR description template as it makes little sense in the demoshop repository - we have no BC promise here and nobody depends on this repository...
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
