### PR TITLE
prototype of solution for PHPStan (and PHPStorm) errors caused by usage of extended services from framework

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,7 @@
     <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
 
     <property name="is-multidomain" value="true"/>
-    <property name="phpstan.level" value="1"/>
+    <property name="phpstan.level" value="4"/>
 
     <import file="${path.framework}/build.xml"/>
 

--- a/src/Shopsys/ShopBundle/Controller/Admin/CustomerController.php
+++ b/src/Shopsys/ShopBundle/Controller/Admin/CustomerController.php
@@ -64,7 +64,7 @@ class CustomerController extends BaseCustomerController
     protected $customerFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Customer\CustomerDataFactory
      */
     protected $customerDataFactory;
 
@@ -124,7 +124,7 @@ class CustomerController extends BaseCustomerController
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
      * @param \Shopsys\FrameworkBundle\Model\Security\LoginAsUserFacade $loginAsUserFacade
      * @param \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory
-     * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface $customerDataFactory
+     * @param \Shopsys\ShopBundle\Model\Customer\CustomerDataFactory $customerDataFactory
      * @param \Shopsys\ShopBundle\Model\Customer\BillingAddressFacade $billingAddressFacade
      * @param \Shopsys\ShopBundle\Model\Customer\BillingAddressDataFactory $billingAddressDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Customer\UserFactory $userFactory
@@ -366,6 +366,7 @@ class CustomerController extends BaseCustomerController
         $customerData = $this->customerDataFactory->createFromUser($user);
 
         $usersByBillingAddress = $this->customerFacade->getAllByBillingAddress($billingAddress);
+
         $customerData->companyUsersData = $this->userDataFactory->createMultipleUserDataFromUsers($usersByBillingAddress);
 
         $form = $this->createForm(CustomerFormType::class, $customerData, [

--- a/src/Shopsys/ShopBundle/Model/Category/Category.php
+++ b/src/Shopsys/ShopBundle/Model/Category/Category.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Model\Category\Category as BaseCategory;
 use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
 
 /**
+ * @property \Shopsys\ShopBundle\Model\Category\CategoryDomain[] $domains
  * @Gedmo\Tree(type="nested")
  * @ORM\Table(name="categories")
  * @ORM\Entity

--- a/src/Shopsys/ShopBundle/Model/Category/Category.php
+++ b/src/Shopsys/ShopBundle/Model/Category/Category.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
 
 /**
  * @property \Shopsys\ShopBundle\Model\Category\CategoryDomain[] $domains
+ * @method \Shopsys\ShopBundle\Model\Category\CategoryDomain getCategoryDomain($domainId)
  * @Gedmo\Tree(type="nested")
  * @ORM\Table(name="categories")
  * @ORM\Entity

--- a/src/Shopsys/ShopBundle/Model/Country/CountryFacade.php
+++ b/src/Shopsys/ShopBundle/Model/Country/CountryFacade.php
@@ -6,6 +6,9 @@ namespace Shopsys\ShopBundle\Model\Country;
 
 use Shopsys\FrameworkBundle\Model\Country\CountryFacade as BaseCountryFacade;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Country\CountryRepository $countryRepository
+ */
 class CountryFacade extends BaseCountryFacade
 {
     /**

--- a/src/Shopsys/ShopBundle/Model/Customer/CurrentCustomer.php
+++ b/src/Shopsys/ShopBundle/Model/Customer/CurrentCustomer.php
@@ -6,6 +6,9 @@ namespace Shopsys\ShopBundle\Model\Customer;
 
 use Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer as BaseCurrentCustomer;
 
+/**
+ * @method \Shopsys\ShopBundle\Model\Customer\User|null findCurrentUser()
+ */
 class CurrentCustomer extends BaseCurrentCustomer
 {
     /**

--- a/src/Shopsys/ShopBundle/Model/Customer/CustomerData.php
+++ b/src/Shopsys/ShopBundle/Model/Customer/CustomerData.php
@@ -9,6 +9,9 @@ use Shopsys\FrameworkBundle\Model\Customer\CustomerData as BaseCustomerData;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData;
 use Shopsys\FrameworkBundle\Model\Customer\UserData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Customer\UserData $userData
+ */
 class CustomerData extends BaseCustomerData
 {
     /**

--- a/src/Shopsys/ShopBundle/Model/Customer/CustomerFacade.php
+++ b/src/Shopsys/ShopBundle/Model/Customer/CustomerFacade.php
@@ -16,6 +16,9 @@ use Shopsys\FrameworkBundle\Model\Customer\Mail\CustomerMailFacade;
 use Shopsys\FrameworkBundle\Model\Customer\UserFactoryInterface;
 use Shopsys\ShopBundle\Model\Customer\Exception\DuplicateEmailsException;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Customer\UserRepository $userRepository
+ */
 class CustomerFacade extends BaseCustomerFacade
 {
     /**

--- a/src/Shopsys/ShopBundle/Model/Order/OrderRepository.php
+++ b/src/Shopsys/ShopBundle/Model/Order/OrderRepository.php
@@ -11,7 +11,7 @@ class OrderRepository extends BaseOrderRepository
 {
     /**
      * @param \Shopsys\ShopBundle\Model\Customer\User[] $users
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
+     * @return \Shopsys\ShopBundle\Model\Order\Order[]
      */
     public function getOrderListByCustomers(array $users)
     {
@@ -30,7 +30,7 @@ class OrderRepository extends BaseOrderRepository
     /**
      * @param string $orderNumber
      * @param \Shopsys\ShopBundle\Model\Customer\BillingAddress $billingAddress
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     * @return \Shopsys\ShopBundle\Model\Order\Order
      */
     public function getByOrderNumberAndBillingAddress($orderNumber, BillingAddress $billingAddress)
     {

--- a/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
+++ b/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
@@ -98,7 +98,10 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
 
-        return $productFacade->getById($productId);
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
+        $product = $productFacade->getById($productId);
+
+        return $product;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want PHPStorm and PHPStand to understand the ways the developers extend the framework so they are able to use higher levels of static analysis and are able to navigate in their code easily. We know we want to use fixer for that and we need to define what and when the fixer should do exactly. 
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
