### PR TITLE
simplification of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,11 @@
 language: bash
-dist: xenial
 
-services:
-    - docker
-
-addons:
-    apt:
-        update: true
 env:
     global:
-        - DOCKER_COMPOSE_VERSION=1.24.0
-        -   DOCKER_COMPOSE_URL="https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
         - TRAVIS_USER_ID=$(id -u)
         - TRAVIS_GROUP_ID=$(id -g)
 
 before_install:
-    - curl -L $DOCKER_COMPOSE_URL > docker-compose
-    - chmod +x docker-compose
-    - sudo mv docker-compose /usr/local/bin
     - cp -f ./docker/conf/docker-compose.yml.dist ./docker-compose.yml
     - "sed -i 's#www_data_uid: 1000#www_data_uid: $TRAVIS_USER_ID#' ./docker-compose.yml"
     - "sed -i 's#www_data_gid: 1000#www_data_uid: $TRAVIS_GROUP_ID#' ./docker-compose.yml"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It seems that Docker Compose is installed on Travis CI by default, there might be no need for complicating the config with installing Docker Compose manually...
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

- `xenial` distro is the default, according to https://docs.travis-ci.com/user/reference/overview/
- both Docker and Docker compose is installed by default, according to https://docs.travis-ci.com/user/reference/xenial/#docker
- `apt.update` addon is not needed as we don't install any dependencies with `apt`