### PR TITLE
universal logging to administration of public demoshop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - simplified configuration of localized router
     - fixed directory path in `shopsys.domain_images_url_prefix`
     - using Elasticsearch as a datasource for Read model
+- [#68 - Universal logging to administration of public demoshop](https://github.com/shopsys/demoshop/pull/68)
+    - admin with ID 2 is now known as default admin
+    - default admin cannot be changed or deleted
 
 ### Fixed
 - [#8 - Category now has second description attribute that is displayed on the product list page above the product list](https://github.com/shopsys/demoshop/pull/8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#68 - Universal logging to administration of public demoshop](https://github.com/shopsys/demoshop/pull/68)
     - admin with ID 2 is now known as default admin
     - default admin cannot be changed or deleted
+    - multiple users can log with same credentials in multiple browsers
 
 ### Fixed
 - [#8 - Category now has second description attribute that is displayed on the product list page above the product list](https://github.com/shopsys/demoshop/pull/8)

--- a/app/Resources/ShopsysFrameworkBundle/views/Admin/Inline/Menu/menu.html.twig
+++ b/app/Resources/ShopsysFrameworkBundle/views/Admin/Inline/Menu/menu.html.twig
@@ -1,0 +1,50 @@
+<ul class="js-toggle-menu navig navig--side">
+    <li class="js-toggle-menu-item navig__item">
+        <div class="box-dropdown">
+            <div
+                    class="box-dropdown__select"
+                    title="{{ 'Frontend'|trans }}"
+            >
+                {{ 'Go to Frontend'|trans }}
+                <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
+                <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
+            </div>
+            <ul class="js-toggle-menu-submenu box-dropdown__options">
+                {% for domainConfig in domainConfigs %}
+                    <li class="box-dropdown__options__item">
+                        <a href="{{ domainConfig.url }}" target="_blank" class="box-dropdown__options__item__link" title="{{ domainConfig.name }}">{{ domainConfig.url }}</a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </li>
+
+    <li class="js-toggle-menu-item navig__item">
+        <div class="box-dropdown">
+            <div
+                    class="box-dropdown__select box-dropdown__select--with-icon"
+                    title="{{ 'Account'|trans }}
+            >
+                <i class="svg svg-person-man"></i>
+                {{ app.user.realName }}
+                <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
+                <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
+            </div>
+            <ul class="js-toggle-menu-submenu box-dropdown__options">
+                
+                {% if not app.user.defaultAdmin %}
+                    <li class="box-dropdown__options__item">
+                        <a href="{{ url('admin_administrator_myaccount') }}" class="box-dropdown__options__item__link" title="{{ 'My account'|trans }}">
+                            {{ 'My account'|trans }}
+                        </a>
+                    </li>
+                {% endif %}
+                <li class="box-dropdown__options__item">
+                    <a href="{{ url('admin_logout', { _csrf_token: csrf_token('admin_logout')}) }}" class="box-dropdown__options__item__link" title="{{ 'Log out'|trans }}">
+                        {{ 'Log out'|trans }}
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </li>
+</ul>

--- a/app/config/parameters_common.yml
+++ b/app/config/parameters_common.yml
@@ -28,3 +28,4 @@ parameters:
         Shopsys\FrameworkBundle\Model\Transport\Transport: Shopsys\ShopBundle\Model\Transport\Transport
         Shopsys\FrameworkBundle\Model\Customer\BillingAddress: Shopsys\ShopBundle\Model\Customer\BillingAddress
         Shopsys\FrameworkBundle\Model\Customer\User: Shopsys\ShopBundle\Model\Customer\User
+        Shopsys\FrameworkBundle\Model\Administrator\Administrator: Shopsys\ShopBundle\Model\Administrator\Administrator

--- a/src/Shopsys/ShopBundle/Controller/Admin/AdministratorController.php
+++ b/src/Shopsys/ShopBundle/Controller/Admin/AdministratorController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Controller\Admin;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Shopsys\FrameworkBundle\Controller\Admin\AdministratorController as BaseAdministratorController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class AdministratorController extends BaseAdministratorController
+{
+    /**
+     * @Route("/administrator/edit/{id}", requirements={"id" = "\d+"})
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int $id
+     */
+    public function editAction(Request $request, $id)
+    {
+        /** @var \Shopsys\ShopBundle\Model\Administrator\Administrator $administrator */
+        $administrator = $this->administratorFacade->getById($id);
+
+        if ($administrator->isDefaultAdmin()) {
+            $message = 'Default admin cannot be edited.';
+            throw new AccessDeniedException($message);
+        }
+
+        return parent::editAction($request, $id);
+    }
+}

--- a/src/Shopsys/ShopBundle/DataFixtures/Demo/AdministratorDataFixture.php
+++ b/src/Shopsys/ShopBundle/DataFixtures/Demo/AdministratorDataFixture.php
@@ -6,6 +6,8 @@ namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
 
 class AdministratorDataFixture extends AbstractReferenceFixture
@@ -19,11 +21,18 @@ class AdministratorDataFixture extends AbstractReferenceFixture
     protected $administratorFacade;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade $administratorFacade
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface
      */
-    public function __construct(AdministratorFacade $administratorFacade)
+    private $administratorDataFactory;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade $administratorFacade
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface $administratorDataFactory
+     */
+    public function __construct(AdministratorFacade $administratorFacade, AdministratorDataFactoryInterface $administratorDataFactory)
     {
         $this->administratorFacade = $administratorFacade;
+        $this->administratorDataFactory = $administratorDataFactory;
     }
 
     /**
@@ -33,6 +42,14 @@ class AdministratorDataFixture extends AbstractReferenceFixture
     {
         $this->createAdministratorReference(1, self::SUPERADMINISTRATOR);
         $this->createAdministratorReference(2, self::ADMINISTRATOR);
+
+        $administratorData = $this->administratorDataFactory->create();
+        $administratorData->username = 'admintest';
+        $administratorData->realName = 'Admin Test';
+        $administratorData->email = 'no-reply@shopsys.com';
+        $administratorData->password = 'admin123';
+
+        $this->administratorFacade->create($administratorData);
     }
 
     /**

--- a/src/Shopsys/ShopBundle/Model/Administrator/Administrator.php
+++ b/src/Shopsys/ShopBundle/Model/Administrator/Administrator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Administrator;
+
+use Doctrine\ORM\Mapping as ORM;
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator as BaseAdministrator;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(
+ *   name="administrators",
+ *   indexes={
+ *     @ORM\Index(columns={"username"})
+ *   }
+ * )
+ */
+class Administrator extends BaseAdministrator
+{
+    public const DEFAULT_ADMIN_ID = 2;
+
+    /**
+     * @return bool
+     */
+    public function isDefaultAdmin(): bool
+    {
+        return $this->getId() === self::DEFAULT_ADMIN_ID;
+    }
+}

--- a/src/Shopsys/ShopBundle/Model/Administrator/AdministratorFacade.php
+++ b/src/Shopsys/ShopBundle/Model/Administrator/AdministratorFacade.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Administrator;
+
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator as BaseAdministrator;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade as BaseAdministratorFacade;
+
+class AdministratorFacade extends BaseAdministratorFacade
+{
+    /**
+     * @param \Shopsys\ShopBundle\Model\Administrator\Administrator $administrator
+     */
+    protected function checkForDelete(BaseAdministrator $administrator)
+    {
+        parent::checkForDelete($administrator);
+
+        if ($administrator->isDefaultAdmin()) {
+            throw new \Shopsys\ShopBundle\Model\Administrator\Exception\DeletingDefaultAdminException();
+        }
+    }
+}

--- a/src/Shopsys/ShopBundle/Model/Administrator/AdministratorRepository.php
+++ b/src/Shopsys/ShopBundle/Model/Administrator/AdministratorRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Administrator;
+
+use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository as BaseAdministratorRepository;
+
+class AdministratorRepository extends BaseAdministratorRepository
+{
+    /**
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getAllListableQueryBuilder(): QueryBuilder
+    {
+        return $this->getAdministratorRepository()
+            ->createQueryBuilder('a')
+            ->where('a.superadmin = :isSuperadmin')
+            ->setParameter('isSuperadmin', false)
+            ->andWhere('a.id != :defaultAdminId')
+            ->setParameter('defaultAdminId', Administrator::DEFAULT_ADMIN_ID);
+    }
+}

--- a/src/Shopsys/ShopBundle/Model/Administrator/Exception/DeletingDefaultAdminException.php
+++ b/src/Shopsys/ShopBundle/Model/Administrator/Exception/DeletingDefaultAdminException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Administrator\Exception;
+
+use Exception;
+use Shopsys\FrameworkBundle\Model\Administrator\Exception\AdministratorException;
+
+class DeletingDefaultAdminException extends Exception implements AdministratorException
+{
+}

--- a/src/Shopsys/ShopBundle/Model/Administrator/Security/AdministratorUserProvider.php
+++ b/src/Shopsys/ShopBundle/Model/Administrator/Security/AdministratorUserProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Administrator\Security;
+
+use DateTime;
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorUserProvider as BaseAdministratorUserProvider;
+use Shopsys\FrameworkBundle\Model\Security\TimelimitLoginInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class AdministratorUserProvider extends BaseAdministratorUserProvider
+{
+    /**
+     * @param \Symfony\Component\Security\Core\User\UserInterface $userInterface
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator
+     */
+    public function refreshUser(UserInterface $userInterface)
+    {
+        $class = get_class($userInterface);
+        if (!$this->supportsClass($class)) {
+            $message = sprintf('Instances of "%s" are not supported.', $class);
+            throw new \Symfony\Component\Security\Core\Exception\UnsupportedUserException($message);
+        }
+
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
+        $administrator = $userInterface;
+
+        $freshAdministrator = $this->administratorRepository->findById($administrator->getId());
+
+        if ($administrator instanceof TimelimitLoginInterface) {
+            if (time() - $administrator->getLastActivity()->getTimestamp() > 3600 * 5) {
+                throw new \Symfony\Component\Security\Core\Exception\AuthenticationExpiredException('Admin was too long inactive.');
+            }
+            if ($freshAdministrator !== null) {
+                $freshAdministrator->setLastActivity(new DateTime());
+            }
+        }
+
+        if ($freshAdministrator === null) {
+            throw new \Symfony\Component\Security\Core\Exception\UsernameNotFoundException('Unable to find an active admin');
+        }
+
+        if ($freshAdministrator instanceof Administrator) {
+            $this->administratorActivityFacade->updateCurrentActivityLastActionTime($freshAdministrator);
+        }
+
+        return $freshAdministrator;
+    }
+}

--- a/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -178,3 +178,5 @@ services:
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository: '@Shopsys\ShopBundle\Model\Administrator\AdministratorRepository'
 
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade: '@Shopsys\ShopBundle\Model\Administrator\AdministratorFacade'
+
+    Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorUserProvider: '@Shopsys\ShopBundle\Model\Administrator\Security\AdministratorUserProvider'

--- a/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -174,3 +174,7 @@ services:
     Shopsys\ShopBundle\DataFixtures\Demo\UserDataFixtureLoader:
         arguments:
             - '%shopsys.data_fixtures.resource_customers_filepath%'
+
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository: '@Shopsys\ShopBundle\Model\Administrator\AdministratorRepository'
+
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade: '@Shopsys\ShopBundle\Model\Administrator\AdministratorFacade'

--- a/src/Shopsys/ShopBundle/Resources/config/services_test.yml
+++ b/src/Shopsys/ShopBundle/Resources/config/services_test.yml
@@ -104,3 +104,7 @@ services:
         class: Shopsys\ShopBundle\Model\Customer\CurrentCustomer
 
     Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
+
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository: '@Shopsys\ShopBundle\Model\Administrator\AdministratorRepository'
+
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade: '@Shopsys\ShopBundle\Model\Administrator\AdministratorFacade'

--- a/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
+++ b/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
@@ -151,7 +151,7 @@ class RouteConfigCustomization
             ->customize(function (RouteConfig $config, RouteInfo $info) {
                 if (preg_match('~^admin_~', $info->getRouteName())) {
                     $config->changeDefaultRequestDataSet('Log as "admin" to administration.')
-                        ->setAuth(new BasicHttpAuth('admin', 'admin123'));
+                        ->setAuth(new BasicHttpAuth('admintest', 'admin123'));
                 }
             })
             ->customize(function (RouteConfig $config, RouteInfo $info) {
@@ -181,8 +181,8 @@ class RouteConfigCustomization
                 $config->addExtraRequestDataSet('Superadmin can edit superadmin')
                     ->setAuth(new BasicHttpAuth('superadmin', 'admin123'))
                     ->setExpectedStatusCode(200);
-                $config->addExtraRequestDataSet('Editing normal administrator (with ID 2) should be OK.')
-                    ->setParameter('id', 2)
+                $config->addExtraRequestDataSet('Editing normal administrator (with ID 3) should be OK.')
+                    ->setParameter('id', 3)
                     ->setExpectedStatusCode(200);
             })
             ->customizeByRouteName('admin_administrator_myaccount', function (RouteConfig $config) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| On public demoshop we need to have administrator, that cannot be changed or deleted so users can always log into administration with same credentials. Also we need to enable multiple users to log with same credentials.
|New feature| Yes <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
