### PR TITLE
fix of PhpStan configuration

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,6 @@ parameters:
         - '#Undefined variable: \$undefined#'
         # Add ignored errors here as regular expressions, e.g.:
         # - '#PHPUnit_Framework_MockObject_MockObject(.*) given#'
-    includes:
-        - vendor/phpstan/phpstan-doctrine/extension.neon
-        - vendor/phpstan/phpstan-phpunit/extension.neon
+includes:
+    - vendor/phpstan/phpstan-doctrine/extension.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
     ignoreErrors:
         - '#Undefined variable: \$undefined#'
-        # Add ignored errors here as regular expressions, e.g.:
-        # - '#PHPUnit_Framework_MockObject_MockObject(.*) given#'
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| PhpStan extensions were not loaded because of a mistake in configuration introduced in #53 (see [diff](https://github.com/shopsys/demoshop/pull/53/files#diff-e4ce1df0d2ca17a9d91544a50ace127a))
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| fixes #65 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes