### PR TITLE
php pod is resolved by running status now on renew

### DIFF
--- a/.ci/renewable-deploy/renewal-script.sh
+++ b/.ci/renewable-deploy/renewal-script.sh
@@ -11,7 +11,7 @@ kubectl config set-context --current --namespace=production
 # Listing pods to know what is really running - only for debugging purposes
 kubectl get pods -l app=webserver-php-fpm
 # Find running webserver and postgres
-POD_PHP_FPM=$(kubectl get pods -l app=webserver-php-fpm -o=jsonpath='{.items[0].metadata.name}')
+POD_PHP_FPM=$(kubectl get pods -l app=webserver-php-fpm | grep "Running" | awk '{print $1}')
 POD_POSTGRES=$(kubectl get pods -l app=postgres -o=jsonpath='{.items[0].metadata.name}')
 
 # Download fashionable data from google storage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When demoshop is renewed, it was possible the main pod was resolved as the currently terminating one. This PR fixes this.
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
