### PR TITLE
Fix user permissions for php-fpm in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
 
 before_install:
     - cp -f ./docker/conf/docker-compose.yml.dist ./docker-compose.yml
-    - "sed -i 's#www_data_uid: 1000#www_data_uid: $TRAVIS_USER_ID#' ./docker-compose.yml"
-    - "sed -i 's#www_data_gid: 1000#www_data_uid: $TRAVIS_GROUP_ID#' ./docker-compose.yml"
+    - "sed -i \"s#www_data_uid: 1000#www_data_uid: $TRAVIS_USER_ID#\" ./docker-compose.yml"
+    - "sed -i \"s#www_data_gid: 1000#www_data_gid: $TRAVIS_GROUP_ID#\" ./docker-compose.yml"
 
 install:
     - docker-compose up -d postgres elasticsearch redis selenium-server php-fpm webserver


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Travis builds started failing on user's permissions when installing `npm`. This PR fixes user permissions in `php-fpm` container. 
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
