### PR TITLE
fix order checkbox behaviour

### DIFF
--- a/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.twig
+++ b/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.twig
@@ -51,7 +51,8 @@
 {% block checkbox_row %}
     <dl class="{{ rowClass|default('form-line') }}">
         <div class="form-choice">
-            {{ form_widget(form, { attr: { class: "css-checkbox" } }) }}
+            {% set checkboxAttr = attr|merge({'class': (attr.class|default('') ~ ' css-checkbox')|trim}) %}
+            {{ form_widget(form, { attr: checkboxAttr }) }}
             {{ form_label(form, label, { label_attr: { class: "css-checkbox__image" }}) }}
             {% set errors_attr = errors_attr|default({})|merge({'class': (errors_attr.class|default('form-error--choice'))}) %}
             {{ form_errors(form, { errors_attr: errors_attr } ) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In order process there are not hidden form fields in 3rd step.  This PR fixes forgotten change in form theme.
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Hides form fields in 3rd order step. Fixes open these fields on checkbox click. This issue appears after upgrade.