### PR TITLE
npm prune is not now run when building

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,4 +12,10 @@
 
     <import file="${path.framework}/build.xml"/>
 
+    <target name="npm" description="Installs modules required for Grunt.">
+        <exec executable="${path.npm.executable}" dir="${path.root}" logoutput="true" passthru="true" checkreturn="true">
+            <arg value="install"/>
+        </exec>
+    </target>
+
 </project>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| NPM prune fails because of https://github.com/npm/cli/issues/613 and Travis fails on this. This PR removes npm prune from npm phing target as it's not necessary to run it anyway
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
